### PR TITLE
Updated the .gitignore to include ignoring typescript definitions so …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bower_components/
 
 # Other
 .tmp/
+typings/


### PR DESCRIPTION
…that we can use visual studio code without introducing online definitions.
